### PR TITLE
Update minimum dart version to support null safety

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,8 +5,9 @@ packages:
     dependency: "direct main"
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "5cfd6509652ff5e7fe149b6df4859e687fca9048437857cb2e65c8d780f396e3"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
 sdks:
-  dart: ">=2.17.0-206.0.dev <3.0.0"
+  dart: ">=2.17.0-206.0.dev <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 homepage: https://github.com/dartclub/linter_rules
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0 <4.0.0"
 
 dependencies:
   lints: ^2.0.0


### PR DESCRIPTION
When I check out `turf_dart` on my machine and run `dart pub get` it aborts and complains that this package doesn't support null safety. It looks like null safety was introduced in sdk 2.12, and given it was quite long time ago I think it would be safe to update the minimum sdk version from 2.7 to 2.12. 

Changing the dartclub_lint dependency in pubspec.yaml to the commit in this PR fixes the dependency resolve error.

I locally use dart 3.2.5, that comes with current last stable flutter release (3.16.8). 

**Breaking Change**: This does break support for those using dart lower than [2.12](https://dart.dev/guides/language/evolution#dart-212) (released 3 March 2021).